### PR TITLE
fix(kafka-exporter): fixed can't create bug

### DIFF
--- a/pkg/entity/kafka_exporter/kafka_exporter.go
+++ b/pkg/entity/kafka_exporter/kafka_exporter.go
@@ -60,6 +60,7 @@ func create(name *string, cmd *cobra.Command) {
 	// key streams not yet supported in data model!
 	exporter := &entities.KafkaExporter{
 		StreamRef: &entities.StreamRef{BillingId: common.BillingId, Name: *name},
+		Ref: &entities.KafkaExporterRef{BillingId: common.BillingId},
 	}
 
 	response, err := client.CreateKafkaExporter(


### PR DESCRIPTION
The billing id wasn't set in the ref inside the create message.