### PR TITLE
fix: proper auth success and failure redirects after login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,10 @@ require (
 	github.com/actgardner/gogen-avro/v7 v7.3.1
 	github.com/bykof/gostradamus v1.0.4
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-rod/rod v0.101.8 // indirect
+	github.com/go-rod/rod v0.101.8
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.2
-	github.com/int128/oauth2cli v1.13.0
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/joho/godotenv v1.3.0
 	github.com/magiconair/properties v1.8.5
@@ -26,6 +25,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/streammachineio/api-definitions-go v1.21.1-0.20210922103820-01a69205c68b //v1.16.0
 	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/trietsch/oauth2cli v1.13.1-0.20211005100207-e9a0b788d614
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/int128/listener v1.1.0 h1:2Jb41DWLpkQ3I9bIdBzO8H/tNwMvyl/OBZWtCV5Pjuw=
 github.com/int128/listener v1.1.0/go.mod h1:68WkmTN8PQtLzc9DucIaagAKeGVyMnyyKIkW4Xn47UA=
-github.com/int128/oauth2cli v1.13.0 h1:3wR48gSHdOPFgHmtnXzs4wEFA6p24prPqLXu6QUOujw=
-github.com/int128/oauth2cli v1.13.0/go.mod h1:EUpEzcUumoVjLPHD7y2KGxwfXYqxDVqwDfqQ+u7qAwM=
 github.com/jedib0t/go-pretty/v6 v6.2.4 h1:wdaj2KHD2W+mz8JgJ/Q6L/T5dB7kyqEFI16eLq7GEmk=
 github.com/jedib0t/go-pretty/v6 v6.2.4/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoMwqZnuiK2r2a0=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -259,10 +257,16 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trietsch/oauth2cli v1.13.1-0.20211005094053-f2a16dde3dd2 h1:UWMKAnBkgxlyy5ZLmue8zdC6o1osB54ruNxKQ4fhn+I=
+github.com/trietsch/oauth2cli v1.13.1-0.20211005094053-f2a16dde3dd2/go.mod h1:UP0F4n4ywpN8HJ3YhmijNS2NaH/uwepJP63hExUCagY=
+github.com/trietsch/oauth2cli v1.13.1-0.20211005100207-e9a0b788d614 h1:h2ZYmBR2pWl1h3iU53vEHt1uqg3jE+qAq8J0N9rg/E4=
+github.com/trietsch/oauth2cli v1.13.1-0.20211005100207-e9a0b788d614/go.mod h1:UP0F4n4ywpN8HJ3YhmijNS2NaH/uwepJP63hExUCagY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/ysmood/goob v0.3.0 h1:XZ51cZJ4W3WCoCiUktixzMIQF86W7G5VFL4QQ/Q2uS0=
 github.com/ysmood/goob v0.3.0/go.mod h1:S3lq113Y91y1UBf1wj1pFOxeahvfKkCk6mTWTWbDdWs=
+github.com/ysmood/got v0.15.1 h1:X5jAbMyBf5yeezuFMp9HaMGXZWMSqIQcUlAHI+kJmUs=
 github.com/ysmood/got v0.15.1/go.mod h1:pE1l4LOwOBhQg6A/8IAatkGp7uZjnalzrZolnlhhMgY=
+github.com/ysmood/gotrace v0.2.2 h1:006KHGRThSRf8lwh4EyhNmuuq/l+Ygs+JqojkhEG1/E=
 github.com/ysmood/gotrace v0.2.2/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
 github.com/ysmood/gson v0.6.4 h1:Yb6tosv6bk59HqjZu2/7o4BFherpYEMkDkXmlhgryZ4=
 github.com/ysmood/gson v0.6.4/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3RNmg=

--- a/pkg/auth/user.go
+++ b/pkg/auth/user.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/int128/oauth2cli"
 	"github.com/pkg/browser"
 	log "github.com/sirupsen/logrus"
 	"github.com/streammachineio/api-definitions-go/api/account/v1"
+	"github.com/trietsch/oauth2cli"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 	"net"
@@ -88,7 +88,8 @@ func (authenticator *Authenticator) Login() {
 		OAuth2Config:           oAuth2Config(),
 		LocalServerReadyChan:   ready,
 		LocalServerBindAddress: strings.Split(fmt.Sprintf("127.0.0.1:%d", port), ","),
-		LocalServerSuccessHTML: common.AuthSuccessHTML,
+		SuccessRedirectUrl: "https://streammachine.io/auth-success",
+		FailureRedirectUrl: "https://streammachine.io/auth-failure",
 		AuthCodeOptions: []oauth2.AuthCodeOption{
 			oauth2.SetAuthURLParam("prompt", "login"),
 		},

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -8,8 +8,6 @@ var ConfigPath string
 // For example, --api-host is bound to STRM_API_HOST
 const EnvPrefix = "STRM"
 
-const AuthSuccessHTML = `<html><head><meta http-equiv="refresh" content="0; url=https://streammachine.io"/></head><body></body></html>`
-
 const DefaultConfigFilename = "strm"
 const DefaultConfigFileSuffix = ".yaml"
 


### PR DESCRIPTION
Temporarily switched from https://github.com/int128/oauth2cli to https://github.com/trietsch/oauth2cli/tree/strm, until [the PR for the redirect URL functionality](https://github.com/int128/oauth2cli/pull/54) has been merged in the upstream repository.